### PR TITLE
Minor cleanup proposals

### DIFF
--- a/examples/generate_2fa_token.adb
+++ b/examples/generate_2fa_token.adb
@@ -6,7 +6,6 @@ with LSC.Byte_Arrays;
 with OTP;
 with OTP.T;
 with Base32;
-use all type LSC.Types.Index;
 
 procedure Generate_2fa_Token
   with SPARK_Mode

--- a/src/base32.ads
+++ b/src/base32.ads
@@ -32,8 +32,8 @@ is
      with
        Dynamic_Predicate =>
          Base32_String'Length mod 8 = 0 and
-         (for all C in Base32_String'Range =>
-            Valid_Base32_Character (Base32_String (C)));
+         (for all C of Base32_String =>
+            Valid_Base32_Character (C));
 
    -- Decode Base32 string into a byte array
    -- @param S Valid Base32 string

--- a/src/base32.ads
+++ b/src/base32.ads
@@ -14,9 +14,7 @@ is
    function Valid_Base32_Character
      (C : Character) return Boolean
    is
-     ((Character'Pos (C) > 96 and Character'Pos (C) < 123) or
-        (Character'Pos (C) > 64 and Character'Pos (C) < 91) or
-          (Character'Pos (C) > 49 and Character'Pos (C) < 56))
+     (C in 'a' .. 'z' | 'A' .. 'Z' | '2' .. '7')
          with
            Depends => (Valid_Base32_Character'Result => C);
 

--- a/src/base32.ads
+++ b/src/base32.ads
@@ -104,8 +104,8 @@ private
    function Decode_2 (C2 : Character;
                       C3 : Character;
                       C4 : Character) return Byte is
-     (Shift_Left (Byte (Decode_Map (C2)), 6) or
-          Shift_Left (Byte (Decode_Map (C3)), 1) or
+     (Shift_Left (Decode_Map (C2), 6) or
+          Shift_Left (Decode_Map (C3), 1) or
           Shift_Right (Decode_Map (C4), 4))
      with
        Depends => (Decode_2'Result => (C2, C3, C4)),
@@ -116,7 +116,7 @@ private
 
    function Decode_3 (C4 : Character;
                       C5 : Character) return Byte is
-     (Shift_Left (Byte (Decode_Map (C4)), 4) or
+     (Shift_Left (Decode_Map (C4), 4) or
           Shift_Right (Decode_Map (C5), 1))
      with
        Depends => (Decode_3'Result => (C4, C5)),

--- a/src/base32.ads
+++ b/src/base32.ads
@@ -1,7 +1,6 @@
 with Interfaces;
 with LSC.Types;
 with LSC.Byte_Arrays;
-use all type LSC.Types.Index;
 
 -- @summary
 -- Base32 encoder and decoder

--- a/src/hmac.ads
+++ b/src/hmac.ads
@@ -19,7 +19,7 @@ is
       return HMAC_Type
      with
        Depends => (SHA1'Result => (Key, Msg)),
-       Pre =>  Key'Length <= 64
+       Pre => Key'Length <= 64
        and Msg'Length <= 64;
 
 end HMAC;

--- a/src/hmac.ads
+++ b/src/hmac.ads
@@ -1,5 +1,4 @@
 with LSC.Byte_Arrays;
-use all type LSC.Byte_Arrays.Byte_Array_Type;
 
 -- @summary
 -- HMAC wrapper

--- a/src/lsc-byte_arrays.adb
+++ b/src/lsc-byte_arrays.adb
@@ -1,6 +1,3 @@
-with LSC.Types;
-use all type LSC.Types.Index;
-
 package body LSC.Byte_Arrays
 with SPARK_Mode
 is

--- a/src/otp-h.adb
+++ b/src/otp-h.adb
@@ -1,6 +1,4 @@
 with Interfaces;
-with LSC.SHA1;
-with LSC.HMAC_SHA1;
 with LSC.Byteorder32;
 with LSC.Byteorder64;
 use all type Interfaces.Unsigned_8;

--- a/src/otp-h.adb
+++ b/src/otp-h.adb
@@ -20,7 +20,7 @@ is
       C : LSC.Byte_Arrays.Byte_Array_Type :=
             LSC.Byte_Arrays.Convert_Byte_Array (LSC.Types.Word64_To_Byte_Array64 (
                                                 LSC.Byteorder64.Native_To_BE(Counter)));
-      Mac     : HMAC.HMAC_Type;
+      Mac : HMAC.HMAC_Type;
    begin
       Mac := HMAC.SHA1 (Key, C);
       return Extract(Mac);

--- a/src/otp.adb
+++ b/src/otp.adb
@@ -1,4 +1,3 @@
-
 package body OTP
 with SPARK_Mode
 is

--- a/tests/test_hotp.adb
+++ b/tests/test_hotp.adb
@@ -4,8 +4,6 @@ with LSC.Byte_Arrays;
 with HMAC;
 with OTP;
 with OTP.H;
-use all type OTP.OTP_Token;
-use all type OTP.OTP_Value;
 
 procedure Test_HOTP
   with SPARK_Mode

--- a/tests/test_sha1_hmac.adb
+++ b/tests/test_sha1_hmac.adb
@@ -1,12 +1,7 @@
 with Ada.Text_IO;
 
-with LSC.Byteorder32;
-with LSC.Types;
 with LSC.Byte_Arrays;
-with LSC.SHA1;
-with LSC.HMAC_SHA1;
 with HMAC;
-use all type LSC.Types.Index;
 use all type LSC.Byte_Arrays.Byte_Array_Type;
 
 procedure Test_Sha1_Hmac


### PR DESCRIPTION
Nice work, thanks for sharing!

As for the unnecessary conversions and extra USE clauses, I found them by enabling extra warnings in gnat, i.e. adding this section to the stotp.gpr project file:

```
   package Compiler is
      for Switches ("ada") use ("-gnatwa");
   end Compiler;
```

You might want to add it and it will also tell you which variables could be declared as constants.